### PR TITLE
Added an endpoint for the avantio-dwellings request [#17182]

### DIFF
--- a/src/Tev/Bs/Endpoint/Dwellings/ListAvantioDwellingsEndpoint.php
+++ b/src/Tev/Bs/Endpoint/Dwellings/ListAvantioDwellingsEndpoint.php
@@ -1,0 +1,21 @@
+<?php namespace Tev\Bs\Endpoint\Dwellings;
+
+use Tev\Bs\Endpoint\AbstractEndpoint;
+
+/**
+ * Endpoint object for /api/avantio-dwellings.
+ *
+ * See: /docs/endpoints#dwellings-list
+ */
+class ListAvantioDwellingsEndpoint extends AbstractEndpoint {
+
+    /**
+     * Retrieve the API URL for this endpoint.
+     *
+     * @return string
+     */
+    protected function apiUrl()
+    {
+        return '/api/avantio-dwellings';
+    }
+}


### PR DESCRIPTION
This is to add an endpoint that will allow the use of the `/api/avantio-dwellings` end-point from the booking-api